### PR TITLE
:sparkles: Se corrigen rutas relativas se instala react-typed

### DIFF
--- a/frontend/CodeJourney/package-lock.json
+++ b/frontend/CodeJourney/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-typed": "^1.2.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.37",
@@ -2018,6 +2019,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2177,6 +2186,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2227,6 +2246,24 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-typed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-typed/-/react-typed-1.2.0.tgz",
+      "integrity": "sha512-aDsaA6zkjAFJs8285APOqE85l/kwJ0/ZJmBhARwUrza4TTttrMM5FcMCGEDdThdfUdHo/0l9WXmxp1m2ik4qdw==",
+      "dependencies": {
+        "prop-types": "^15.6.0",
+        "typed.js": "^2.0.6"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0",
+        "react-dom": "^16.3.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2465,6 +2502,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typed.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed.js/-/typed.js-2.1.0.tgz",
+      "integrity": "sha512-bDuXEf7YcaKN4g08NMTUM6G90XU25CK3bh6U0THC/Mod/QPKlEt9g/EjvbYB8x2Qwr2p6J6I3NrsoYaVnY6wsQ=="
     },
     "node_modules/typescript": {
       "version": "5.3.2",

--- a/frontend/CodeJourney/package.json
+++ b/frontend/CodeJourney/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-typed": "^1.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",

--- a/frontend/CodeJourney/src/App.tsx
+++ b/frontend/CodeJourney/src/App.tsx
@@ -1,10 +1,11 @@
-
+import { Hero } from "./components/hero/Hero"
 
 
 function App() {
   return (
     <>
       <h1>Hola Mundo</h1>
+      <Hero/>
     </>
   )
 }

--- a/frontend/CodeJourney/src/components/hero/Hero.tsx
+++ b/frontend/CodeJourney/src/components/hero/Hero.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import hero_background from "../../../src/assets/video/background.mp4";
+import hero_background from "../../../public/video/2.mp4"
 import "../hero/hero.css";
 import Typed from "react-typed";
 
@@ -8,7 +7,7 @@ export function Hero() {
     <section className="hero">
       <video src={hero_background} autoPlay muted loop />
 
-      <div className="content active">
+        <div className="content active">
         <h1>
           Aprendamos a programar de manera{" "}
           <span>


### PR DESCRIPTION
Se instala react-typed, con la flag --force, debido a que esa libreria solo es compatible con la version 16.3.0, todo funciona con normalidad. Imagenes, videos et. No van en carpeta assets, se mueven a carpeta public. Se corrigen rurtas relativas de video.